### PR TITLE
Inject bean via setter

### DIFF
--- a/src/test/java/com.breskul.bring/ApplicationContextTest.java
+++ b/src/test/java/com.breskul.bring/ApplicationContextTest.java
@@ -4,6 +4,9 @@ import com.breskul.bring.packages.autowired.correct.MessageServiceDemo;
 import com.breskul.bring.packages.autowired.correct.PrinterServiceDemo;
 import com.breskul.bring.exceptions.NoSuchBeanException;
 import com.breskul.bring.exceptions.NoUniqueBeanException;
+import com.breskul.bring.packages.autowired.injectViaSetterCorrect.ListenerServiceSetterInjection;
+import com.breskul.bring.packages.autowired.injectViaSetterCorrect.MessageServiceDemoSetterInjection;
+import com.breskul.bring.packages.autowired.injectViaSetterCorrect.PrinterServiceDemoSetterInjection;
 import com.breskul.bring.packages.components.Component1;
 import com.breskul.bring.packages.components.Component2;
 import com.breskul.bring.packages.components.SameBeanInterface;
@@ -30,7 +33,9 @@ public class ApplicationContextTest {
     private static final String AUTOWIRE_NO_SUCH_BEAN_PACAKGE_NAME = "com.breskul.bring.packages.autowired.nosuchbean";
 
     private static final String CONFIGURATION_PACKAGE_NAME = "com.breskul.bring.packages.configurations";
-
+    private static final String INJECT_VIA_SETTER_PACKAGE_NAME = "com.breskul.bring.packages.autowired.injectViaSetterCorrect";
+    private static final String INJECT_VIA_SETTER_NO_SUCH_BEAN = "com.breskul.bring.packages.autowired.injectViaSetterNoSuchBean";
+    private static final String INJECT_VIA_SETTER_NO_UNIQUE_BEAN = "com.breskul.bring.packages.autowired.injectViaSetterNoUniqueBean";
 
     @Nested
     @Order(1)
@@ -123,7 +128,7 @@ public class ApplicationContextTest {
 
     @Nested
     @Order(3)
-    @DisplayName("2. ApplicationContext Configuration Test")
+    @DisplayName("3. ApplicationContext Configuration Test")
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class ApplicationContextConfigurationTest {
         @Test
@@ -173,6 +178,43 @@ public class ApplicationContextTest {
                 assertTrue(applicationContextMap.containsKey(beanName));
                 assertEquals(beanValue.getClass(), beanValue.getClass());
             }
+        }
+
+    }
+
+    @Nested
+    @Order(3)
+    @DisplayName("4. Inject Bean Via Setter Test")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class InjectBeanViaSetterTest{
+        @Test
+        @Order(1)
+        @DisplayName("Beans are correctly injected via setter")
+        void loadConfiguration()  {
+            ApplicationContext applicationContext = new AnnotationConfigApplicationContext(INJECT_VIA_SETTER_PACKAGE_NAME);
+            ListenerServiceSetterInjection listenerServiceSetterInjection = applicationContext.getBean(ListenerServiceSetterInjection.class);
+            assertEquals(listenerServiceSetterInjection.getClass(), ListenerServiceSetterInjection.class);
+
+            MessageServiceDemoSetterInjection messageServiceDemoSetterInjection = applicationContext.getBean(MessageServiceDemoSetterInjection.class);
+            assertEquals(messageServiceDemoSetterInjection.getClass(), MessageServiceDemoSetterInjection.class);
+            messageServiceDemoSetterInjection.setMessage("MESSAGE_FROM_MESSAGE_SERVICE!");
+            PrinterServiceDemoSetterInjection printerServiceDemoSetterInjection = applicationContext.getBean(PrinterServiceDemoSetterInjection.class);
+            assertEquals(printerServiceDemoSetterInjection.getClass(), PrinterServiceDemoSetterInjection.class);
+
+            printerServiceDemoSetterInjection.printMessage();
+        }
+        @Test
+        @Order(2)
+        @DisplayName("NoSuchBeanException is thrown when there is no bean")
+        void getNoSuchBeanException()  {
+            assertThrows(NoSuchBeanException.class, () -> new AnnotationConfigApplicationContext(INJECT_VIA_SETTER_NO_SUCH_BEAN));
+        }
+
+        @Test
+        @Order(3)
+        @DisplayName("NoUniqueBeanException is thrown when there are 2 or more same class beans")
+        void getNoUniqueBeanException()  {
+            assertThrows(NoUniqueBeanException.class, () -> new AnnotationConfigApplicationContext(INJECT_VIA_SETTER_NO_UNIQUE_BEAN));
         }
 
     }

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterCorrect/ListenerServiceSetterInjection.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterCorrect/ListenerServiceSetterInjection.java
@@ -1,0 +1,12 @@
+package com.breskul.bring.packages.autowired.injectViaSetterCorrect;
+
+import com.breskul.bring.annotations.Component;
+
+@Component
+public class ListenerServiceSetterInjection {
+
+    public void listen(){
+        System.out.println("LISTENING_SERVICE_IS_LISTENING");
+    }
+
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterCorrect/MessageServiceDemoSetterInjection.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterCorrect/MessageServiceDemoSetterInjection.java
@@ -1,0 +1,17 @@
+package com.breskul.bring.packages.autowired.injectViaSetterCorrect;
+
+import com.breskul.bring.annotations.Component;
+
+@Component
+public class MessageServiceDemoSetterInjection {
+
+    private String message;
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterCorrect/PrinterServiceDemoSetterInjection.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterCorrect/PrinterServiceDemoSetterInjection.java
@@ -1,0 +1,21 @@
+package com.breskul.bring.packages.autowired.injectViaSetterCorrect;
+
+import com.breskul.bring.annotations.Bean;
+import com.breskul.bring.annotations.Component;
+
+@Component
+public class PrinterServiceDemoSetterInjection {
+    private MessageServiceDemoSetterInjection messageServiceDemoSetterInjection;
+    private ListenerServiceSetterInjection listenerServiceSetterInjection;
+
+    @Bean
+    public void setMessageService(MessageServiceDemoSetterInjection messageServiceDemoSetterInjection, ListenerServiceSetterInjection listenerServiceSetterInjection){
+        this.messageServiceDemoSetterInjection = messageServiceDemoSetterInjection;
+        this.listenerServiceSetterInjection = listenerServiceSetterInjection;
+    }
+
+    public void printMessage() {
+        System.out.println(messageServiceDemoSetterInjection.getMessage());
+        listenerServiceSetterInjection.listen();
+    }
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoSuchBean/ComponentInstance.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoSuchBean/ComponentInstance.java
@@ -1,0 +1,20 @@
+package com.breskul.bring.packages.autowired.injectViaSetterNoSuchBean;
+
+import com.breskul.bring.annotations.Bean;
+import com.breskul.bring.annotations.Component;
+
+import java.lang.reflect.Field;
+
+@Component
+public class ComponentInstance {
+
+    Field nonExistentComponent;
+
+    @Bean
+    public void setNonExistentComponent(Field nonExistentComponent) {
+        this.nonExistentComponent = nonExistentComponent;
+    }
+
+    public ComponentInstance() {
+    }
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/ComponentInstance1.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/ComponentInstance1.java
@@ -1,0 +1,9 @@
+package com.breskul.bring.packages.autowired.injectViaSetterNoUniqueBean;
+
+import com.breskul.bring.annotations.Component;
+
+
+@Component
+public class ComponentInstance1 implements SameInterface {
+
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/ComponentInstance2.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/ComponentInstance2.java
@@ -1,0 +1,7 @@
+package com.breskul.bring.packages.autowired.injectViaSetterNoUniqueBean;
+
+import com.breskul.bring.annotations.Component;
+
+@Component
+public class ComponentInstance2 implements SameInterface {
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/Componentinstnace3.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/Componentinstnace3.java
@@ -1,0 +1,15 @@
+package com.breskul.bring.packages.autowired.injectViaSetterNoUniqueBean;
+
+import com.breskul.bring.annotations.Bean;
+import com.breskul.bring.annotations.Component;
+
+@Component
+public class Componentinstnace3 {
+
+    private SameInterface sameInterface;
+
+    @Bean
+    public void setSameInterface(SameInterface sameInterface) {
+        this.sameInterface = sameInterface;
+    }
+}

--- a/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/SameInterface.java
+++ b/src/test/java/com.breskul.bring/packages/autowired/injectViaSetterNoUniqueBean/SameInterface.java
@@ -1,0 +1,4 @@
+package com.breskul.bring.packages.autowired.injectViaSetterNoUniqueBean;
+
+public interface SameInterface {
+}


### PR DESCRIPTION
1. did some small comments refactoring
2. removed some boilerplate code. 3. 
`Map<Class<?>, String> fieldTypeStringNameMap = new HashMap<>();
                Class<?> beanClass = beanInstance.getClass();
                for (Field field : beanClass.getDeclaredFields()) {
                    fieldTypeStringNameMap.put(field.getType(), field.getName());
}` 
Now **_fieldTypeStringNameMap_** has only one instance and it is reused

3. Added injection via setter
4. Added tests for injection via setter 

